### PR TITLE
Added user roles + admin specific pages

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,17 @@
+class AdminController < ApplicationController
+  def index
+  end
+
+  def games
+    @games = Game.all
+  end
+
+  def reviews
+  end
+
+  def users
+  end
+
+  def show_game
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,2 @@
+module AdminHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  enum role: [:user, :admin]
+
   # makes user name case-insensitive
   validates :username, presence: true, uniqueness: {case_sensitive: false}
 

--- a/app/views/admin/games.html.erb
+++ b/app/views/admin/games.html.erb
@@ -1,0 +1,11 @@
+<div class="container">
+    <div id="games">
+    <% @games.each do |game| %>
+      <%= render game %>
+      <p>
+        <%= link_to "Show this game", game %>
+      </p>
+    <% end %>
+    </div>
+    <%= link_to "New game", new_game_path, class:'btn btn-primary'%>
+</div>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,0 +1,8 @@
+<div class = "container">
+    <h1>Admin#index</h1>
+    <p>Find me in app/views/admin/index.html.erb</p>
+    <%=link_to "Edit Games", admin_games_path, class:"btn btn-primary"%>
+    <%=link_to "Edit Reviews", admin_reviews_path, class:"btn btn-primary"%>
+    <%=link_to "Edit Users", admin_users_path, class:"btn btn-primary"%>
+
+</div>

--- a/app/views/admin/reviews.html.erb
+++ b/app/views/admin/reviews.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin#reviews</h1>
+<p>Find me in app/views/admin/reviews.html.erb</p>

--- a/app/views/admin/show_game.html.erb
+++ b/app/views/admin/show_game.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin#show_game</h1>
+<p>Find me in app/views/admin/show_game.html.erb</p>

--- a/app/views/admin/users.html.erb
+++ b/app/views/admin/users.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin#users</h1>
+<p>Find me in app/views/admin/users.html.erb</p>

--- a/app/views/user/_session_manager.html.erb
+++ b/app/views/user/_session_manager.html.erb
@@ -4,11 +4,21 @@
             <%= current_user.username %>
         </a>
         <ul class="dropdown-menu dropdown-menu-lg-end" aria-labelledby="navbarDropdown">
-
+            
             <li><%= link_to "Profile", user_path(current_user.id), class:'dropdown-item' %></li>
             <li><%= link_to "Settings", edit_user_registration_path, class:'dropdown-item' %></li>
-            <li><hr class="dropdown-divider"></li>
             
+            <% if current_user.admin? %>
+                <li><hr class="dropdown-divider"></li>
+
+                <li><h5 style="color:rgba(255, 0, 0, 0.75)" class="dropdown-header">Admin</h5></li>
+                
+                <li><%= link_to "Edit Games", admin_games_path, class:'dropdown-item' %></li>
+                <li><%= link_to "Edit Reviews", admin_reviews_path, class:'dropdown-item' %></li>
+                <li><%= link_to "Edit Users", admin_users_path, class:'dropdown-item' %></li>
+            <% end %>
+
+            <li><hr class="dropdown-divider"></li>
             <li><%= button_to "Sign Out", destroy_user_session_path, method: :delete, class:'dropdown-item' %></li>
         </ul>
     </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,14 @@
 Rails.application.routes.draw do
+  
+  # only load pages for admin users
+  authenticated :user, ->(user) {user.admin?} do
+    get 'admin', to: 'admin#index'
+    get 'admin/games'
+    get 'admin/reviews'
+    get 'admin/users'
+    get 'admin/show_game'
+  end
+
   get 'users/profile'
   devise_for :users, controllers: {
     sessions: 'users/sessions',
@@ -8,6 +18,7 @@ Rails.application.routes.draw do
 
   get '/u/:id', to: 'users#profile', as: 'user'
   get 'about', to: 'pages#about'
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20240414015931_add_role_to_user.rb
+++ b/db/migrate/20240414015931_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_13_162534) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_14_015931) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,13 +28,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_13_162534) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
+    t.string "username"
+    t.integer "role", default: 0
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class AdminControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get admin_index_url
+    assert_response :success
+  end
+
+  test "should get games" do
+    get admin_games_url
+    assert_response :success
+  end
+
+  test "should get reviews" do
+    get admin_reviews_url
+    assert_response :success
+  end
+
+  test "should get users" do
+    get admin_users_url
+    assert_response :success
+  end
+
+  test "should get show_games" do
+    get admin_show_games_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
### Added the admin role.

Currently all that is coded are some pages, and additional dropdown menu items, which are inaccessible by accounts which do not have admin access. In order to access the admin functionalities you need to have a user that has the admin role. By default the role for each user is **not** set to admin. Other than seeding the database with an admin account at startup, another way to set a user's role is to follow the instructions below:

1. Open the ruby console: Type "rails c" in WSL
2. Type in the following:
`@user = user.first`
`@user.role = 1`
`@user.save`



_EDIT: Make sure that you have at least one user stored in your database before executing the code above. This can be done with .create / .add functions in the ruby console OR by using the signup on the rails site_ 

